### PR TITLE
Ensure log directory exists before configuring logging

### DIFF
--- a/core/main.py
+++ b/core/main.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from pathlib import Path
 from mqtt.client import MQTTClient
 from storage.mongo import MongoStorage
 from devices import load_devices_from_config
@@ -8,11 +9,13 @@ from utils.config import load_config
 
 async def main():
     # 初始化日志
+    log_dir = Path(__file__).resolve().parent / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
     logging.basicConfig(
         level=logging.INFO,
         format='%(asctime)s [%(levelname)s] %(message)s',
         handlers=[
-            logging.FileHandler("logs/simulator.log"),
+            logging.FileHandler(log_dir / "simulator.log"),
             logging.StreamHandler()
         ]
     )


### PR DESCRIPTION
## Summary
- import `Path` and create log directory automatically
- reference the new directory when creating the log file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fa3b1229c8325ad8b2d84ab3ff8e8