### PR TITLE
Improve Tailwind content paths

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -4,7 +4,11 @@ import defaultTheme from 'tailwindcss/defaultTheme'
 export default {
   content: [
     "./index.html",
-    "./**/*.{vue,ts,js,html}"
+    "./App.vue",
+    "./main.ts",
+    "./router.ts",
+    "./pages/**/*.{vue,ts,js,html}",
+    "./utils/**/*.{ts,js}"
   ],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- tighten Tailwind `content` globs to avoid scanning `node_modules`

## Testing
- `npm run build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684fab59f02c8325920e75134ae62ebf