### PR TITLE
Fix lint errors

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -23,9 +23,16 @@ app.include_router(ws_router)  # ✅ 注册 WebSocket 路由
 load_dotenv()
 MONGO_URL = os.getenv("MONGO_URL", "mongodb://localhost:27017")
 DB_NAME = os.getenv("DB_NAME", "virtual_devices")
-LOG_PATH = Path(os.getenv("LOG_PATH", Path(__file__).parent.parent / "core" / "logs" / "simulator.log"))
+LOG_PATH = Path(
+    os.getenv(
+        "LOG_PATH",
+        Path(__file__).parent.parent / "core" / "logs" / "simulator.log",
+    )
+)
 
-client = motor.motor_asyncio.AsyncIOMotorClient(MONGO_URL, serverSelectionTimeoutMS=1000)
+client = motor.motor_asyncio.AsyncIOMotorClient(
+    MONGO_URL, serverSelectionTimeoutMS=1000
+)
 db = client[DB_NAME]
 
 

--- a/backend/websocket_devices.py
+++ b/backend/websocket_devices.py
@@ -3,7 +3,7 @@ import asyncio
 import motor.motor_asyncio
 from dotenv import load_dotenv
 import os
-import datetime
+
 
 router = APIRouter()
 
@@ -12,6 +12,7 @@ MONGO_URL = os.getenv("MONGO_URL", "mongodb://localhost:27017")
 DB_NAME = os.getenv("DB_NAME", "virtual_devices")
 client = motor.motor_asyncio.AsyncIOMotorClient(MONGO_URL)
 db = client[DB_NAME]
+
 
 @router.websocket("/ws/devices")
 async def websocket_device_updates(websocket: WebSocket):

--- a/core/devices/__init__.py
+++ b/core/devices/__init__.py
@@ -21,7 +21,16 @@ def load_devices_from_config(devices_config, mqtt_client, mongo):
                 did = make_did()
                 config = dict(auto_cfg)
                 config["static"] = False
-                devices.append(create_device(dev_type, pid, did, mqtt_client, mongo, config))
+                devices.append(
+                    create_device(
+                        dev_type,
+                        pid,
+                        did,
+                        mqtt_client,
+                        mongo,
+                        config,
+                    )
+                )
 
         # 静态设备
         if "static" in cfg:
@@ -30,7 +39,16 @@ def load_devices_from_config(devices_config, mqtt_client, mongo):
                 did = make_did()
                 config = dict(static_cfg)
                 config["static"] = True
-                devices.append(create_device(dev_type, pid, did, mqtt_client, mongo, config))
+                devices.append(
+                    create_device(
+                        dev_type,
+                        pid,
+                        did,
+                        mqtt_client,
+                        mongo,
+                        config,
+                    )
+                )
 
     return devices
 
@@ -47,7 +65,10 @@ def create_device(dev_type, pid, did, mqtt_client, mongo, config):
             "motion_sensors": "motion",
         }
         config["device_class"] = device_class_map.get(dev_type, "temperature")
-        config.setdefault("unit", "°C" if config["device_class"] == "temperature" else "%")
+        config.setdefault(
+            "unit",
+            "°C" if config["device_class"] == "temperature" else "%",
+        )
         return Sensor(pid, did, mqtt_client, mongo, config)
     else:
         raise ValueError(f"未知的设备类型: {dev_type}")

--- a/core/devices/air_conditioner.py
+++ b/core/devices/air_conditioner.py
@@ -1,8 +1,8 @@
 import asyncio
 import random
 import logging
-import uuid
 import json
+
 
 class AirConditioner:
     def __init__(self, pid, did, mqtt_client, mongo, config):
@@ -76,7 +76,10 @@ class AirConditioner:
 
     def simulate_status(self):
         # 简单模拟状态变化
-        self.state["envtemp"] = round(self.state["envtemp"] + random.uniform(-0.5, 0.5), 1)
+        self.state["envtemp"] = round(
+            self.state["envtemp"] + random.uniform(-0.5, 0.5),
+            1,
+        )
 
     async def publish_discovery(self):
         topic = f"homeassistant/climate/{self.pid}/{self.did}/config"
@@ -108,8 +111,13 @@ class AirConditioner:
             "fan_modes": ["auto", "low", "medium", "high"],
             "value_template": "{{ value_json.temp }}",
             "current_temperature_template": "{{ value_json.envtemp }}",
-            "fan_mode_value_template": "{{ ['auto', 'low', 'medium', 'high'][value_json.ac_mark] }}",
-            "mode_state_template": "{{ ['off','cool','heat','dry','fan_only'][value_json.ac_mode] if value_json.pwr else 'off' }}"
+            "fan_mode_value_template": (
+                "{{ ['auto', 'low', 'medium', 'high'][value_json.ac_mark] }}"
+            ),
+            "mode_state_template": (
+                "{{ ['off','cool','heat','dry','fan_only'][value_json.ac_mode]"
+                " if value_json.pwr else 'off' }}"
+            )
         }
         await self.mqtt.publish(topic, payload, retain=True)
 

--- a/core/devices/light.py
+++ b/core/devices/light.py
@@ -37,7 +37,15 @@ class Light:
             data = payload
 
         if isinstance(data, dict):
-            for key in ["pwr", "brightness", "colortemp", "red", "green", "blue", "bulb_colormode"]:
+            for key in [
+                "pwr",
+                "brightness",
+                "colortemp",
+                "red",
+                "green",
+                "blue",
+                "bulb_colormode",
+            ]:
                 if key in data:
                     self.state[key] = int(data[key])
             return
@@ -73,12 +81,30 @@ class Light:
 
     def simulate_status(self):
         if self.state["bulb_colormode"] == 0:
-            self.state["red"] = max(0, min(255, self.state["red"] + random.randint(-10, 10)))
-            self.state["green"] = max(0, min(255, self.state["green"] + random.randint(-10, 10)))
-            self.state["blue"] = max(0, min(255, self.state["blue"] + random.randint(-10, 10)))
+            self.state["red"] = max(
+                0,
+                min(255, self.state["red"] + random.randint(-10, 10)),
+            )
+            self.state["green"] = max(
+                0,
+                min(255, self.state["green"] + random.randint(-10, 10)),
+            )
+            self.state["blue"] = max(
+                0,
+                min(255, self.state["blue"] + random.randint(-10, 10)),
+            )
         else:
-            self.state["colortemp"] = max(2500, min(6500, self.state["colortemp"] + random.randint(-200, 200)))
-        self.state["brightness"] = max(0, min(100, self.state["brightness"] + random.randint(-5, 5)))
+            self.state["colortemp"] = max(
+                2500,
+                min(
+                    6500,
+                    self.state["colortemp"] + random.randint(-200, 200),
+                ),
+            )
+        self.state["brightness"] = max(
+            0,
+            min(100, self.state["brightness"] + random.randint(-5, 5)),
+        )
 
     async def publish_discovery(self):
         topic = f"homeassistant/light/{self.pid}/{self.did}/config"
@@ -96,17 +122,33 @@ class Light:
             "brightness_state_topic": f"home/{self.did}/status",
             "brightness_command_topic": f"home/{self.did}/brightness/set",
             "brightness_value_template": "{{ value_json.brightness }}",
-            "brightness_command_template": "{\"brightness\": {{value}},\"bulb_colormode\":1}",
+            "brightness_command_template": (
+                "{\"brightness\": {{value}},\"bulb_colormode\":1}"
+            ),
             "color_mode_state_topic": f"home/{self.did}/status",
-            "color_mode_value_template": "{{ 'rgb' if value_json.bulb_colormode == 0 else 'color_temp' }}",
-            "color_temp_value_template": "{{ (1000000 / value_json.colortemp) | int }}",
+            "color_mode_value_template": (
+                "{{ 'rgb' if value_json.bulb_colormode == 0 "
+                "else 'color_temp' }}"
+            ),
+            "color_temp_value_template": (
+                "{{ (1000000 / value_json.colortemp) | int }}"
+            ),
             "color_temp_state_topic": f"home/{self.did}/status",
-            "color_temp_command_template": "{\"colortemp\": {{(1000000 / value) | int}},\"bulb_colormode\":1}",
+            "color_temp_command_template": (
+                "{\"colortemp\": {{(1000000 / value) | int}},"
+                "\"bulb_colormode\":1}"
+            ),
             "color_temp_command_topic": f"home/{self.did}/colortemp/set",
             "rgb_state_topic": f"home/{self.did}/status",
             "rgb_command_topic": f"home/{self.did}/rgb/set",
-            "rgb_command_template": "{\"red\":{{red}},\"green\":{{green}},\"blue\":{{blue}},\"bulb_colormode\":0}",
-            "rgb_value_template": "{{ value_json.red }},{{ value_json.green }},{{ value_json.blue }}",
+            "rgb_command_template": (
+                "{\"red\":{{red}},\"green\":{{green}},"
+                "\"blue\":{{blue}},\"bulb_colormode\":0}"
+            ),
+            "rgb_value_template": (
+                "{{ value_json.red }},{{ value_json.green }},"
+                "{{ value_json.blue }}"
+            ),
             "device": {
                 "identifiers": [f"did_{self.did}"],
                 "name": self.name,

--- a/core/devices/sensor.py
+++ b/core/devices/sensor.py
@@ -31,7 +31,10 @@ class Sensor:
             data = payload
         if isinstance(data, dict) and "value" in data:
             self.value = float(data["value"])
-        elif isinstance(data, (int, float)) or str(data).replace('.', '', 1).isdigit():
+        elif (
+            isinstance(data, (int, float))
+            or str(data).replace(".", "", 1).isdigit()
+        ):
             self.value = float(data)
 
     async def run(self):
@@ -42,12 +45,19 @@ class Sensor:
         while self.running and not self.static:
             self.simulate_status()
             await self.publish_status()
-            await self.mongo.insert(self.did, self.device_class, {"value": self.value})
+            await self.mongo.insert(
+                self.did,
+                self.device_class,
+                {"value": self.value},
+            )
             await asyncio.sleep(self.update_interval)
 
     def simulate_status(self):
         delta = random.uniform(-0.3, 0.3)
-        self.value = round(min(max(self.value + delta, self.range[0]), self.range[1]), 1)
+        self.value = round(
+            min(max(self.value + delta, self.range[0]), self.range[1]),
+            1,
+        )
 
     async def publish_discovery(self):
         topic = f"homeassistant/sensor/{self.pid}/{self.did}/config"
@@ -69,7 +79,10 @@ class Sensor:
         await self.mqtt.publish(topic, payload, retain=True)
 
     async def publish_status(self):
-        await self.mqtt.publish(f"home/{self.did}/status", {"value": self.value})
+        await self.mqtt.publish(
+            f"home/{self.did}/status",
+            {"value": self.value},
+        )
 
     async def publish_availability(self, status):
         await self.mqtt.publish(f"home/{self.did}/available", status)

--- a/core/main.py
+++ b/core/main.py
@@ -68,4 +68,3 @@ if __name__ == "__main__":
         asyncio.run(main())
     except KeyboardInterrupt:
         print("程序中断退出")
-

--- a/core/mqtt/client.py
+++ b/core/mqtt/client.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import json
 from aiomqtt import Client, MqttError
@@ -61,14 +60,20 @@ class MQTTClient:
                     async for msg in messages:
                         try:
                             if self.callback:
-                                await self.callback(msg.topic, msg.payload.decode())
+                                await self.callback(
+                                    msg.topic,
+                                    msg.payload.decode(),
+                                )
                         except Exception as e:
                             self.logger.warning(f"MQTT 消息处理异常: {e}")
             else:
                 async for msg in self.client.messages:
                     try:
                         if self.callback:
-                            await self.callback(msg.topic, msg.payload.decode())
+                            await self.callback(
+                                msg.topic,
+                                msg.payload.decode(),
+                            )
                     except Exception as e:
                         self.logger.warning(f"MQTT 消息处理异常: {e}")
         except MqttError as e:

--- a/core/storage/mongo.py
+++ b/core/storage/mongo.py
@@ -3,6 +3,7 @@ import logging
 import datetime
 import asyncio
 
+
 class MongoStorage:
     def __init__(self, config):
         self.logger = logging.getLogger("MongoStorage")
@@ -14,13 +15,17 @@ class MongoStorage:
     async def connect(self, retries=5, delay=3):
         for attempt in range(retries):
             try:
-                self.client = motor.motor_asyncio.AsyncIOMotorClient(self.mongo_url)
+                self.client = motor.motor_asyncio.AsyncIOMotorClient(
+                    self.mongo_url
+                )
                 await self.client.server_info()
                 self.db = self.client[self.db_name]
                 self.logger.info(f"连接 MongoDB 成功: {self.db_name}")
                 return
             except Exception as e:
-                self.logger.warning(f"MongoDB 连接失败 (尝试 {attempt+1}/{retries}): {e}")
+                self.logger.warning(
+                    f"MongoDB 连接失败 (尝试 {attempt + 1}/{retries}): {e}"
+                )
                 await asyncio.sleep(delay)
         raise RuntimeError("无法连接 MongoDB")
 
@@ -47,6 +52,8 @@ class MongoStorage:
                     expireAfterSeconds=ttl_seconds,
                     name="timestamp_ttl"
                 )
-                self.logger.info(f"设置 TTL 索引: {name}.timestamp ({ttl_seconds}秒)")
+                self.logger.info(
+                    f"设置 TTL 索引: {name}.timestamp ({ttl_seconds}秒)"
+                )
         except Exception as e:
             self.logger.error(f"设置 TTL 索引失败: {e}")


### PR DESCRIPTION
## Summary
- fix line length and spacing for backend API
- clean up unused imports and add spacing in websocket devices
- adjust device creation helper for readability
- tidy air conditioner device logic
- break long lines in light and sensor devices
- remove unused code and break lines in MQTT client
- clean up Mongo storage operations
- trim trailing newline in main

## Testing
- `flake8 backend core`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684fab7e3818832590f2d38646b45cf8