### PR TITLE
Fix MQTT topic handling and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,31 +253,7 @@ devices:
 - 每个设备由程序自动分配唯一 `did`（设备ID），例如：`temp_0001`, `light_0003`。
 - DID 生成格式可基于：设备类型前缀 + 自增编号
 - 所有自动与静态设备的 `did` 均唯一，不重用
-mqtt:
-  host: "127.0.0.1"
-  port: 1883
-  username: "user"
-  password: "pass"
 
-database:
-  mongo_url: "mongodb://localhost:27017"
-  db_name: "virtual_devices"
-
-devices:
-  air_conditioners:
-    pid: 1101
-    count: 2
-    update_interval: 10
-  lights:
-    pid: 1201
-    count: 5
-    update_interval: 5
-  temperature_sensors:
-    pid: 1301
-    count: 4
-    range: [18, 32]
-    update_interval: 6
-```
 
 # 前端仪表板概览（frontend/）
 

--- a/core/mqtt/client.py
+++ b/core/mqtt/client.py
@@ -61,14 +61,14 @@ class MQTTClient:
                     async for msg in messages:
                         try:
                             if self.callback:
-                                await self.callback(msg.topic, msg.payload.decode())
+                                await self.callback(str(msg.topic), msg.payload.decode())
                         except Exception as e:
                             self.logger.warning(f"MQTT 消息处理异常: {e}")
             else:
                 async for msg in self.client.messages:
                     try:
                         if self.callback:
-                            await self.callback(msg.topic, msg.payload.decode())
+                            await self.callback(str(msg.topic), msg.payload.decode())
                     except Exception as e:
                         self.logger.warning(f"MQTT 消息处理异常: {e}")
         except MqttError as e:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,6 @@ pytest
 pytest-asyncio
 httpx
 websockets
+fastapi
+motor
+python-dotenv


### PR DESCRIPTION
## Summary
- ensure MQTT topics are passed as strings to callback
- include backend deps in `requirements-dev.txt`
- remove duplicated YAML example from README

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684facd88a5c8325add408b3a41ea307