### PR TITLE
Fix static device status and MQTT topic handling

### DIFF
--- a/core/devices/air_conditioner.py
+++ b/core/devices/air_conditioner.py
@@ -67,6 +67,8 @@ class AirConditioner:
         await self.publish_discovery()
         await asyncio.sleep(1)
         await self.publish_availability("online")
+        await self.publish_status()
+        await self.mongo.insert(self.did, "air_conditioner", self.state)
 
         while self.running and not self.static:
             self.simulate_status()

--- a/core/devices/light.py
+++ b/core/devices/light.py
@@ -64,6 +64,8 @@ class Light:
         await self.publish_discovery()
         await asyncio.sleep(1)
         await self.publish_availability("online")
+        await self.publish_status()
+        await self.mongo.insert(self.did, "light", self.state)
 
         while self.running and not self.static:
             self.simulate_status()

--- a/core/devices/sensor.py
+++ b/core/devices/sensor.py
@@ -38,6 +38,8 @@ class Sensor:
         await self.publish_discovery()
         await asyncio.sleep(1)
         await self.publish_availability("online")
+        await self.publish_status()
+        await self.mongo.insert(self.did, self.device_class, {"value": self.value})
 
         while self.running and not self.static:
             self.simulate_status()

--- a/core/mqtt/client.py
+++ b/core/mqtt/client.py
@@ -61,14 +61,14 @@ class MQTTClient:
                     async for msg in messages:
                         try:
                             if self.callback:
-                                await self.callback(msg.topic, msg.payload.decode())
+                                await self.callback(str(msg.topic), msg.payload.decode())
                         except Exception as e:
                             self.logger.warning(f"MQTT 消息处理异常: {e}")
             else:
                 async for msg in self.client.messages:
                     try:
                         if self.callback:
-                            await self.callback(msg.topic, msg.payload.decode())
+                            await self.callback(str(msg.topic), msg.payload.decode())
                     except Exception as e:
                         self.logger.warning(f"MQTT 消息处理异常: {e}")
         except MqttError as e:


### PR DESCRIPTION
## Summary
- fix MQTT client callback to convert topic object to string
- publish status once for static devices when run starts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684faddae3688325aa3a3332a5f1b441