### PR TITLE
Fix MQTT topic string handling

### DIFF
--- a/core/mqtt/client.py
+++ b/core/mqtt/client.py
@@ -62,7 +62,7 @@ class MQTTClient:
                             if self.callback:
 
                                 await self.callback(
-                                    msg.topic,
+                                    str(msg.topic),
                                     msg.payload.decode(),
                                 )
                                 
@@ -74,7 +74,7 @@ class MQTTClient:
                         if self.callback:
 
                             await self.callback(
-                                msg.topic,
+                                str(msg.topic),
                                 msg.payload.decode(),
                             )
 


### PR DESCRIPTION
## Summary
- ensure MQTT message topics are passed as strings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fc4ad200c8325b917954322090744